### PR TITLE
Initializing System.cpp Variables to stop spurious boot crashes

### DIFF
--- a/Classic99v4/EmulatorSupport/System.cpp
+++ b/Classic99v4/EmulatorSupport/System.cpp
@@ -22,6 +22,9 @@ Classic99System::Classic99System()
     ioSpaceWrite = new PeripheralMap(&dummyPeripheral, 0, 0);
     memorySize = 0;
     ioSize = 0;
+    hold=0;
+    holdack=0;
+    intReqLevel=0;
     currentTimestamp = 0.0;
 }
 

--- a/Classic99v4/EmulatorSupport/System.cpp
+++ b/Classic99v4/EmulatorSupport/System.cpp
@@ -24,6 +24,7 @@ Classic99System::Classic99System()
     ioSize = 0;
     hold=0;
     holdack=0;
+    nmiReq=false;
     intReqLevel=0;
     currentTimestamp = 0.0;
 }

--- a/Classic99v4/Systems/TexasInstruments/TI994.cpp
+++ b/Classic99v4/Systems/TexasInstruments/TI994.cpp
@@ -15,12 +15,12 @@
 TI994::TI994()
     : Classic99System()
     , pPSG(nullptr)
-    , pVDP(nullptr)
-    , pRom(nullptr)
-    , pGrom(nullptr)
-    , pCPU(nullptr)
-    , pKey(nullptr)
     , pScratch(nullptr)
+    , pGrom(nullptr)
+    , pRom(nullptr) 
+    , pVDP(nullptr)
+    , pKey(nullptr)
+    , pCPU(nullptr)
 {
 }
 

--- a/Classic99v4/Systems/TexasInstruments/TI994.h
+++ b/Classic99v4/Systems/TexasInstruments/TI994.h
@@ -35,13 +35,13 @@ public:
 
 protected:
     // the hardware we need to create
-    TMS9900 *pCPU;
+    SN76xxx *pPSG;
+    TI994Scratchpad *pScratch;
     Classic99GROM *pGrom;
     Classic99ROM *pRom;
-    TI994Scratchpad *pScratch;
     TMS9918 *pVDP;                      // will be a 9918A on the 99/4A variant, could also be an F18A eventually
-    SN76xxx *pPSG;
     TIKeyboard *pKey;
+    TMS9900 *pCPU;
 };
 
 #endif


### PR DESCRIPTION
Initialized all variables in System.cpp
Cleaned up the ordering of initializing classes in TI994 so they don't give compile time warnings